### PR TITLE
chore: Update from ubuntu-latest to goto-linux [DT-4647]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ env:
 jobs:
   build-and-scan:
     name: Build and scan image
-    runs-on: goto-linux
+    runs-on:
+      group: goto-linux
 
     steps:
       - name: Check out the repository

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ env:
 jobs:
   build-and-scan:
     name: Build and scan image
-    runs-on: ubuntu-latest
+    runs-on: goto-linux
 
     steps:
       - name: Check out the repository


### PR DESCRIPTION
This PR updates all ubuntu-latest GitHub runners to the on-prem goto-linux GitHub runners.