### PR TITLE
fix: emitted sarif file [PRODSECREQ-6007]

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41167,7 +41167,7 @@ function formatSarifResults(results) {
         locations: [{
           physicalLocation: {
             artifactLocation: {
-              uri: `${finding.packagePath || imageName}`,
+              uri: `${finding.packagePath || ''}`,
             },
             region: {
               startLine: 1,

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ function formatSarifResults(results) {
         locations: [{
           physicalLocation: {
             artifactLocation: {
-              uri: `${finding.packagePath || imageName}`,
+              uri: `${finding.packagePath || ''}`,
             },
             region: {
               startLine: 1,


### PR DESCRIPTION
contain empty string if no packagePath available